### PR TITLE
Strengthing Anchoring

### DIFF
--- a/mpcd/headers/mpc.h
+++ b/mpcd/headers/mpc.h
@@ -73,7 +73,7 @@ void localCM( cell *CL,spec *SP,specSwimmer specS );
 void localCM_SRD( cell CL,spec *SP,double r_cm[] );
 void localMomInertiaTensor( cell *CL,spec *SP,specSwimmer specS );
 double localMomInertia_SRD( cell CL,spec *SP,double r0[],double n[] );
-void ghostPart( cell ***CL,bc WALL[],double KBT,int LC );
+void ghostPart( cell ***CL,bc WALL[],double KBT,int LC, spec *SP);
 
 void scramble( particleMPC *p );
 void checkEscape_all( particleMPC *pp );


### PR DESCRIPTION
mpc.h and mpc.c changes.  This is to make anchoring stronger.  Using the ghost particle routine, the orientations of the particles in the cells (intersected by a boundary), are set to the anchoring orientation. LCcollision then averages at the preferred anchoring cell director, the individual orientations near the director and, in the case of flat walls, all orientations are aligned with the director