### PR TITLE
Added fix for activity timestep size dependence

### DIFF
--- a/mpcd/subroutines/lc.c
+++ b/mpcd/subroutines/lc.c
@@ -1470,6 +1470,9 @@ void dipoleAndersenROT_LC( cell *CL,spec *SP,specSwimmer SS,double KBT,double RE
 	//If DIPOLE_DIR_AV then use the average value everywhere
 	if( RTECH==DIPOLE_DIR_AV ) ACT *= nDNST/((double)CL->POP);
 
+	// Scale activity by the timestep size to remove timestep dependence
+	ACT *= dt;
+
 	/* ****************************************** */
 	/* ******* Generate random velocities ******* */
 	/* ****************************************** */


### PR DESCRIPTION
Small fix so that activity is now done in units of "per timestep". This is a fix for making activity more consistent for varying timestep sizes.
Note that effective operating range has now been pushed a decade to 10^(-2) to 10^(-1). 