### PR TITLE
update input guide for checkpointing clarity

### DIFF
--- a/docs/InputGuide.md
+++ b/docs/InputGuide.md
@@ -105,7 +105,7 @@ Tag             | Type          | Default Value | Description
 `swimOOut`      | int           | 0             | Swimmer orientations
 `swimROut`      | int           | 0             | Swimmer run/ tumble
 `synopsisOut`   | int           | 1             | Synopsis output. Highly recommended to be on. 1 = on, 0 = off
-`checkpointOut` | int           | 0             | Simulation checkpointing. Unlike all other `out` tags this **will** work during the warmup stage. Note that this just controls dump rate --- To actually load a saved checkpoint, set `seed` to -1
+`checkpointOut` | int           | 0             | Simulation checkpointing. Unlike all other `out` tags this **will** work during the warmup stage, and will overwrite the file every time it runs. Note that this just controls dump rate --- To actually load a saved checkpoint, set `seed` to -1
 ---             | ---           | ---           | ---
 `BC`            | array(BC)     | PBCs around domain | The array of boundary objects. See the BC table for BC tags.
 ---             | ---           | ---           | ---


### PR DESCRIPTION
Update the input guide reference file for some more clarity in how the checkpoint system works. As it was it was a bit confusing about whether you need to set `seed=-1` to store checkpoints