### PR TITLE
Flow dumping fix

### DIFF
--- a/mpcd/subroutines/pout.c
+++ b/mpcd/subroutines/pout.c
@@ -545,7 +545,7 @@ void avenstrophyheader( FILE *fout ) {
 }
 void flowheader( FILE *fout ) {
 /* Simple header for output columns */
-	fprintf( fout,"   QX\t   QY\t   QZ\tVcmX\t\tVcmY\t\tVcmZ\n" );
+	fprintf( fout,"   t\t   QX\t   QY\t   QZ\tVcmX\t\tVcmY\t\tVcmZ\n" );
 }
 void solidsheader( FILE *fout ) {
 /* Simple header for output columns */


### PR DESCRIPTION
Currently, flow fields are not dumped on the first timestep, and there is no explicit timestamping for the flow fields either. This PR fixes both issues with a couple of line changes. Closes #53 

**Note: This will break some existing analysis scripts**. To fix:
- Your flow field parsers should take into account the new time parameter being dumped. This can be done easily by just changing your `split("\t")` line to take an additional param, which can simply be `_`.
- If you any of your scripts have a hack which "resyncs" the flow field to other fields (since flowfield.dat will always contain 1 less field than others before this PR), remove it.

This is being merged to TK-RemoveDupes, to allow me to fix the corresponding flow field scripts there before going to master.