### PR TITLE
Particle updates per second counter

### DIFF
--- a/mpcd/headers/definitions.h
+++ b/mpcd/headers/definitions.h
@@ -46,7 +46,7 @@
 // /// @brief Use the legacy Mersenne Twister RNG. Comment out to use the Xoroshiro RNG.
 // # define RNG_MERSENNE
 /// @brief Enable the floating point signal handlers.
-#define FPE
+// #define FPE
 
 /* ****************************************** */
 /* ************ PROGRAM CONSTANTS *********** */

--- a/mpcd/mpcd.c
+++ b/mpcd/mpcd.c
@@ -120,7 +120,7 @@ int main(int argc, char* argv[]) {
     /* ****************************************** */
     /* ****************************************** */
     #ifdef FPE
-    feenableexcept(FE_INVALID | FE_OVERFLOW | FE_DIVBYZERO);
+    	feenableexcept(FE_INVALID | FE_OVERFLOW | FE_DIVBYZERO);
     #endif
 
 	/* ****************************************** */

--- a/mpcd/subroutines/cJson.c
+++ b/mpcd/subroutines/cJson.c
@@ -359,14 +359,15 @@ void getJObjStr(cJSON *cJSONRoot, const char* jsonTag, const char* d, char **toR
 /// - 1: Error opening the file
 /// - 2: Error allocating memory for the string
 /// - 3: Error reading the file
-///
+///x
 /// @param inFile The file pointer to be read from.
 /// @param fileStr A string that will contain the contents of the file. Expecting to be passed an object of form
 /// `&myStr`.
 /// @return Returns 0 if successful, otherwise returns a pseudo-error code.
 ///
 int getFileStr(char* inFile, char** fileStr){
-   printf("Reading file %s \n", inFile);
+
+	// printf("Reading file %s \n", inFile);
    
    FILE *fptr;
    // read file in with basic error checking


### PR DESCRIPTION
Following the DSFD conference I realised it would be more helpful to have a direct way to compare the computational efficiency of our simulator to others. To this end, I have added a particle updates per second counter to MPCD (PUPS). This does the calculation of $\text{timesteps} \cdot N_{tot} / \text{CPU time}$, and appends K or M to it if necessary. 

Currently this only does the calculation for MPCD particles, and doesn't take boundaries, swimmers, or MD monomers into account. Several UPS calculators could be implmeneted for these, but they would require their own timers, and the MPCD PUPS should be representative of the overall simulation performance.