### PR TITLE
Fixed warmup dependence on MD being initialised

### DIFF
--- a/mpcd/mpcd.c
+++ b/mpcd/mpcd.c
@@ -258,9 +258,11 @@ int main(int argc, char* argv[]) {
 		if(outFlags.SYNOUT == OUT) fprintf( outFiles.fsynopsis,"\nBegin warmup loop.\n" );
 		// This is the main loop of the SRD program. The temporal loop. 
 		starttime=warmtime;
-		if(simMD->warmupMD){
-			WMD = 1;
-		}
+        if (simMD != NULL) {
+            if(simMD->warmupMD){
+                WMD = 1;
+            }
+        }
 		for( warmtime=starttime; warmtime<=inputVar.warmupSteps; warmtime++ ) {
 			/* ****************************************** */
 			/* ***************** UPDATE ***************** */


### PR DESCRIPTION
Fix to a regression. A line of code was added to the warmup loop that made the assumption that MD was initialised, causing a segfault if it was not. Simple null check fixed this.