### PR TITLE
Add -fcommon flag to compilation to fix for newer gcc versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ objects    = $(sources:.c=.o)
 
 # other variables
 cc         :=  gcc
-cflags     :=  -Wall
+cflags     :=  -Wall -fcommon
 lib        :=  -lm
 opt        :=  -O3
 


### PR DESCRIPTION
Adds the -fcommon compilation flag to the makefile. This does a fix that allows for compilation on newer versions of gcc.