### PR TITLE
Add Density-Density correlation function to the OutputGuide.md

### DIFF
--- a/docs/OutputGuide.md
+++ b/docs/OutputGuide.md
@@ -163,6 +163,9 @@ Time `t` given in MPCD units. Separation `dr` given in MPCD units.
 | `velCorrOut`   | `corrVelVel.dat`     | Velocity autocorrelation (radial function)               | Time              | `t`            |
 |                |                      |                                                          | Separation        | `dr`           |
 |                |                      |                                                          | Correlation value | `C`            |
+| `densCorrOut`  | `corrDensDens.dat`   | Density autocorrelation (radial function)                | Time              | `t`            |
+|                |                      |                                                          | Separation        | `dr`           |
+|                |                      |                                                          | Correlation value | `C`            |
 | `dirCorrOut`   | `corrDirDir.dat`     | Director autocorrelation (radial function)               | Time              | `t`            |
 |                |                      |                                                          | Separation        | `dr`           |
 |                |                      |                                                          | Correlation value | `C`            |


### PR DESCRIPTION
Just the other day I looked for correlation functions for my system and found that out instructions section in OutputGuide.md does not contain density correlation function, so I added it to fulfill my obligations