### PR TITLE
Implemented spare caching to the Box-Muller algorithm for generating Gaussian values.

### DIFF
--- a/mpcd/headers/globals.h
+++ b/mpcd/headers/globals.h
@@ -59,4 +59,9 @@ int maxXYZ;
 /// @brief The name of the input file for the MD simulation.
 char* mdInputFile;
 
+/// @brief Whether the Box-Muller transform has a spare value cached.
+int BMHASSPARE;
+/// @brief The spare value from the Box-Muller transform.
+double BMSPARE;
+
 #endif

--- a/mpcd/subroutines/init.c
+++ b/mpcd/subroutines/init.c
@@ -2077,6 +2077,10 @@ void initializeSIM(cell ***CL, particleMPC *SRDparticles, spec SP[], bc WALL[], 
 	}
 	else for( j=0; j<DIM; j++ ) AVV[j]=0.0;
 
+	// initialise global variables relating to box-muller spare caching
+	BMHASSPARE = 0;
+	BMSPARE = 0.0;
+
 	#ifdef DBG
 		if( DBUG >= DBGINIT ) printf( "\tInitialize System\n" );
 		if( DBUG >= DBGINIT ) printf( "\tInitialize MPCD\n" );

--- a/mpcd/subroutines/rand.c
+++ b/mpcd/subroutines/rand.c
@@ -23,6 +23,7 @@
 # include <stdint.h>
 
 # include "../headers/definitions.h"
+#include "../headers/globals.h"
 # include "../headers/SRDclss.h"
 # include "../headers/mtools.h"
 # include "../headers/pout.h"
@@ -476,16 +477,24 @@ float genrand_gauss( void ) {
    StDev of 1. From
    http://www.taygeta.com/random/gaussian.html
 */
-	float x1,x2,w,y1;
-  // 	float y2;
-	do{
-		x1 = 2. * genrand_real() - 1.;
-		x2 = 2. * genrand_real() - 1.;
-		w = x1*x1+x2*x2;
-	} while( w >= 1. );
-	w = sqrt( (-2. * log( w )) / w );
-	y1 = x1*w;
-	return y1;
+	if (BMHASSPARE) {  // if a spare value is cached from a previous run, use it
+		BMHASSPARE = 0;
+		return BMSPARE;
+	} else {  // otherwise, repeat the BM algorithm, caching the spare
+		float x1,x2,w,y1;
+		do{
+			x1 = 2. * genrand_real() - 1.;
+			x2 = 2. * genrand_real() - 1.;
+			w = x1*x1+x2*x2;
+		} while( w >= 1. );
+		w = sqrt( (-2. * log( w )) / w );
+		y1 = x1*w;  // first generated random number
+
+		BMSPARE = x2*w;  // second generated random number
+		BMHASSPARE = 1;
+
+		return y1;
+	}
 }
 
 ///


### PR DESCRIPTION
NIAMH makes use of the Box-Muller algorithm for generating Gaussian random numbers. The algorithm is actually capable of generating two random numbers per run, which is currently not being done. To make use of this, I implemented some functionality to cache this spare value and keep track of whether to use the spare in `genrand_gauss()` within `rand.c`. The values keeping track of the cache I made into globals (in `globals.h`), since there was no nice way to encapsulate this otherwise.

From very rough benchmarking, this has given a ~1.5x performance improvement in compute-bound scenarios. 